### PR TITLE
Evaluate ItemGroups

### DIFF
--- a/src/dotnet-proj-info/Inspect.fs
+++ b/src/dotnet-proj-info/Inspect.fs
@@ -213,7 +213,7 @@ let parsePropertiesOut outFile =
         |> sprintf "invalid temp file content '%A'"
         |> (fun x -> Error (UnexpectedMSBuildResult x))
 
-let getProperties props =
+let getObjects evaluationCharacter props =
     let templateF isCrossgen =
         """
   <Target Name="_Inspect_GetProperties_""" + (if isCrossgen then "CrossGen" else "NotCrossGen") + """"
@@ -226,9 +226,9 @@ let getProperties props =
             |> List.mapi (fun i p -> sprintf """
         <_Inspect_GetProperties_OutLines Include="P%i">
             <PropertyName>%s</PropertyName>
-            <PropertyValue>$(%s)</PropertyValue>
+            <PropertyValue>%c(%s)</PropertyValue>
         </_Inspect_GetProperties_OutLines>
-                                             """ i p p)
+                                             """ i p evaluationCharacter p)
             |> List.map (fun s -> s.TrimEnd())
             |> String.concat (System.Environment.NewLine) )
         +
@@ -266,6 +266,12 @@ let getProperties props =
     template, args, (fun () -> outFile
                                |> bindSkipped parsePropertiesOut
                                |> Result.map Properties)
+
+
+let getProperties props = getObjects '$' props
+
+let getItems items = getObjects '@' items
+
 
 let parseResolvedP2PRefOut outFile =
     /// Example:

--- a/src/dotnet-proj-info/Program.fs
+++ b/src/dotnet-proj-info/Program.fs
@@ -6,6 +6,7 @@ type CLIArguments =
     | Fsc_Args
     | Project_Refs
     | [<AltCommandLine("-gp")>] Get_Property of string list
+    | [<AltCommandLine("-gi")>] Get_Items of string list
     | NET_FW_References_Path of string list
     | Installed_NET_Frameworks
     | [<AltCommandLine("-f")>] Framework of string
@@ -29,6 +30,7 @@ with
             | Runtime _ -> "target runtime, the RuntimeIdentifier msbuild property"
             | Configuration _ -> "configuration to use (like Debug), the Configuration msbuild property"
             | Get_Property _ -> "msbuild property to get (allow multiple)"
+            | Get_Items _ -> "msbuild items to get (allow multiple). For each item, the contents are seperated with a ';'."
             | MSBuild _ -> "MSBuild path (default \"msbuild\")"
             | DotnetCli _ -> "Dotnet CLI path (default \"dotnet\")"
             | MSBuild_Host _ -> "the Msbuild host, if auto then oldsdk=MSBuild dotnetSdk=DotnetCLI"
@@ -185,6 +187,7 @@ let realMain argv = attempt {
         [ results.TryGetResult <@ Fsc_Args @> |> Option.map (fun _ -> getFscArgsBySdk)
           results.TryGetResult <@ Project_Refs @> |> Option.map (fun _ -> getP2PRefs)
           results.TryGetResult <@ Get_Property @> |> Option.map (fun p -> (fun () -> getProperties p))
+          results.TryGetResult <@ Get_Items @> |> Option.map (fun i -> (fun () -> getItems i))
           results.TryGetResult <@ NET_FW_References_Path @> |> Option.map (fun props -> (fun () -> Dotnet.ProjInfo.NETFrameworkInfoFromMSBuild.getReferencePaths props))
           results.TryGetResult <@ Installed_NET_Frameworks @> |> Option.map (fun _ -> Dotnet.ProjInfo.NETFrameworkInfoFromMSBuild.installedNETFrameworks) ]
 


### PR DESCRIPTION
I have a use case where I need to read all ``EmbeddedResource``s from a project file.

This adds a switch to read ItemGroups (compared to ``--get-property`` which reads PropertyGroups).

What do you think?

Thanks