### PR TITLE
support dirname as tool input, restore before execute commands

### DIFF
--- a/src/Dotnet.ProjInfo.Workspace/NETFrameworkInfoProvider.fs
+++ b/src/Dotnet.ProjInfo.Workspace/NETFrameworkInfoProvider.fs
@@ -52,7 +52,7 @@ module internal NETFrameworkInfoProvider =
 
     let result =
         projPath
-        |> getProjectInfo log msbuildExec cmd []
+        |> getProjectInfo log msbuildExec cmd
 
     match result with
     | Ok (Dotnet.ProjInfo.Inspect.GetResult.InstalledNETFw fws) ->
@@ -129,12 +129,12 @@ module internal NETFrameworkInfoProvider =
 
       let runCmd exePath args = Utils.runProcess log projDir exePath (args |> String.concat " ")
 
-      let msbuildExec =
-        msbuild msbuildHost runCmd
+      let msbuildExec proj args =
+        msbuild msbuildHost runCmd proj (props @ args)
 
       let result =
         projPath
-        |> getProjectInfo log msbuildExec cmd props
+        |> getProjectInfo log msbuildExec cmd
 
       match result with
       | Ok (Dotnet.ProjInfo.Inspect.GetResult.ResolvedNETRefs resolvedRefs) ->

--- a/src/Dotnet.ProjInfo.Workspace/ProjectCrackerTypes.fs
+++ b/src/Dotnet.ProjInfo.Workspace/ProjectCrackerTypes.fs
@@ -99,7 +99,13 @@ type [<RequireQualifiedAccess>] WorkspaceProjectState =
 
 module ProjectRecognizer =
 
-    let (|NetCoreProjectJson|NetCoreSdk|Net45|Unsupported|) file =
+    [<RequireQualifiedAccess>]
+    type ProjectSdkKind =
+        | ProjectJson
+        | DotNetSdk
+        | VerboseSdk
+
+    let kindOfProjectSdk file =
         //.NET Core Sdk preview3+ replace project.json with fsproj
         //Easy way to detect new fsproj is to check the msbuild version of .fsproj
         //Post preview5 has (`Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk"`), use that
@@ -110,15 +116,15 @@ module ProjectRecognizer =
             // post preview5 dropped this, check Sdk field
             let isNetCore (line:string) = line.ToLower().Contains("sdk=")
             if limit = 0 then
-                Unsupported // unsupported project type
+                None // unknown project type
             else
                 let line = sr.ReadLine()
                 if not <| line.Contains("ToolsVersion") && not <| line.Contains("Sdk=") then
                     getProjectType sr (limit-1)
                 else // both net45 and preview3-5 have 'ToolsVersion', > 5 has 'Sdk'
-                    if isNetCore line then NetCoreSdk else Net45
+                    if isNetCore line then Some ProjectSdkKind.DotNetSdk else Some ProjectSdkKind.VerboseSdk
         if Path.GetExtension file = ".json" then
-            NetCoreProjectJson // dotnet core preview 2 or earlier
+            Some ProjectSdkKind.ProjectJson // dotnet core preview 2 or earlier
         else
             use sr = File.OpenText(file)
             getProjectType sr 3

--- a/src/dotnet-proj/dotnet-proj.fsproj
+++ b/src/dotnet-proj/dotnet-proj.fsproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Dotnet.ProjInfo\Dotnet.ProjInfo.fsproj" />
     <ProjectReference Include="..\Dotnet.ProjInfo.Helpers\Dotnet.ProjInfo.Helpers.csproj" PrivateAssets="All" />
+    <ProjectReference Include="..\Dotnet.ProjInfo.Workspace\Dotnet.ProjInfo.Workspace.fsproj" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/test/Dotnet.ProjInfo.Workspace.Tests/Tests.fs
+++ b/test/Dotnet.ProjInfo.Workspace.Tests/Tests.fs
@@ -1023,7 +1023,7 @@ let tests (suiteConfig: TestSuiteConfig) =
 
         let msbuildLocator = MSBuildLocator()
 
-        let msbuildPaths = msbuildLocator.InstalledMSBuilds ()
+        let msbuildPaths = msbuildLocator.InstalledMSBuildNET ()
 
         logMsbuild logger msbuildPaths
 
@@ -1035,7 +1035,7 @@ let tests (suiteConfig: TestSuiteConfig) =
 
         let msbuildLocator = MSBuildLocator()
 
-        let msbuildPath = msbuildLocator.LatestInstalledMSBuild ()
+        let msbuildPath = msbuildLocator.LatestInstalledMSBuildNET ()
 
         logMsbuild logger msbuildPath
 


### PR DESCRIPTION
support dirname as input instead of full proj path
restore before execute commands (if .net sdk project)

refactor code to cleanup, remove unused ifdef