### PR TITLE
fix github url

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,10 +6,10 @@
 
   <PropertyGroup>
     <Authors>enricosada</Authors>
-    <PackageProjectUrl>https://github.com/IonideProject/dotnet-proj-info/</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/ionide/dotnet-proj-info/</PackageProjectUrl>
     <PackageTags>msbuild;dotnet;sdk;csproj;fsproj</PackageTags>
-    <RepositoryUrl>https://github.com/IonideProject/dotnet-proj-info.git</RepositoryUrl>
-    <PackageLicenseUrl>https://github.com/enricosada/dotnet-proj-info/blob/master/LICENSE</PackageLicenseUrl>
+    <RepositoryUrl>https://github.com/ionide/dotnet-proj-info.git</RepositoryUrl>
+    <PackageLicenseUrl>https://github.com/ionide/dotnet-proj-info/blob/master/LICENSE</PackageLicenseUrl>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
On Nuget https://www.nuget.org/packages/Dotnet.ProjInfo/
the Project Site leads to an 404
the License info to a fork (of @enricosada)
and the repo URL is also not found.

I assume every link should go here as IonideProject was renamed to ionide only.