### PR TITLE
More performance work

### DIFF
--- a/src/Dotnet.ProjInfo.Workspace/Dotnet.ProjInfo.Workspace.fsproj
+++ b/src/Dotnet.ProjInfo.Workspace/Dotnet.ProjInfo.Workspace.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="..\..\paket-files\Microsoft\visualfsharp\src\fsharp\FSharp.Build\Fsc.fs" />
     <Compile Include="VisualTree.fs" />
     <Compile Include="ProjectCrackerDotnetSdk.fs" />
+    <Compile Include="ProjectCrackerSln.fs" />
     <Compile Include="InspectSln.fs" />
     <Compile Include="MSbuildInfo.fs" />
     <Compile Include="Library.fs" />

--- a/src/Dotnet.ProjInfo.Workspace/Library.fs
+++ b/src/Dotnet.ProjInfo.Workspace/Library.fs
@@ -80,6 +80,7 @@ type Loader private (msbuildHostDotNetSdk, msbuildHostVerboseSdk) =
     member this.LoadProjects(projects: string list, crosstargetingStrategy: CrosstargetingStrategy, useBinaryLogger: bool, ?numberOfThreads : int ) =
         let numberOfThreads = defaultArg numberOfThreads 1
         let cache = ProjectCrackerDotnetSdk.ParsedProjectCache()
+        Dotnet.ProjInfo.Inspect.cleanOutDir ()
 
         let notify arg =
             event1.Trigger(this, arg)

--- a/src/Dotnet.ProjInfo.Workspace/ProjectCrackerDotnetSdk.fs
+++ b/src/Dotnet.ProjInfo.Workspace/ProjectCrackerDotnetSdk.fs
@@ -22,12 +22,6 @@ module internal ProjectCrackerDotnetSdk =
 
   open DotnetProjInfoInspectHelpers
 
-  let msbuildPropProjectOutputType (s: string) =
-    match s.Trim() with
-    | MSBuildPrj.MSBuild.ConditionEquals "Exe" -> ProjectOutputType.Exe
-    | MSBuildPrj.MSBuild.ConditionEquals "Library" -> ProjectOutputType.Library
-    | x -> ProjectOutputType.Custom x
-
   let getExtraInfo props =
     let msbuildPropBool prop =
         props |> Map.tryFind prop |> Option.bind msbuildPropBool

--- a/src/Dotnet.ProjInfo.Workspace/ProjectCrackerSln.fs
+++ b/src/Dotnet.ProjInfo.Workspace/ProjectCrackerSln.fs
@@ -1,0 +1,224 @@
+namespace Dotnet.ProjInfo.Workspace
+
+open System
+open System.IO
+open Dotnet.ProjInfo
+open System.Collections.Concurrent
+open DotnetProjInfoInspectHelpers
+
+module internal ProjectCrackerSln =
+
+  let getExtraInfo props =
+    let msbuildPropBool prop =
+        props |> Map.tryFind prop |> Option.bind msbuildPropBool
+    let msbuildPropStringList prop =
+        props |> Map.tryFind prop |> Option.map msbuildPropStringList
+    let msbuildPropString prop =
+        props |> Map.tryFind prop
+
+    { ProjectSdkTypeDotnetSdk.IsTestProject = msbuildPropBool "IsTestProject" |> Option.defaultValue false
+      Configuration = msbuildPropString "Configuration" |> Option.defaultValue ""
+      IsPackable = msbuildPropBool "IsPackable" |> Option.defaultValue false
+      TargetFramework = msbuildPropString MSBuildKnownProperties.TargetFramework |> Option.defaultValue ""
+      TargetFrameworkIdentifier = msbuildPropString "TargetFrameworkIdentifier" |> Option.defaultValue ""
+      TargetFrameworkVersion = msbuildPropString "TargetFrameworkVersion" |> Option.defaultValue ""
+
+      MSBuildAllProjects = msbuildPropStringList "MSBuildAllProjects" |> Option.defaultValue []
+      MSBuildToolsVersion = msbuildPropString "MSBuildToolsVersion" |> Option.defaultValue ""
+
+      ProjectAssetsFile = msbuildPropString "ProjectAssetsFile" |> Option.defaultValue ""
+      RestoreSuccess = msbuildPropBool "RestoreSuccess" |> Option.defaultValue false
+
+      Configurations = msbuildPropStringList "Configurations" |> Option.defaultValue []
+      TargetFrameworks = msbuildPropStringList "TargetFrameworks" |> Option.defaultValue []
+
+      RunArguments = msbuildPropString "RunArguments"
+      RunCommand = msbuildPropString "RunCommand"
+
+      IsPublishable = msbuildPropBool "IsPublishable" }
+
+  let private mapProjResults (file: string) projData =
+    let (rsp, p2ps, props, projItems) = projData
+
+
+
+
+    // //TODO cache projects info of p2p ref
+    // let p2pProjects : ParsedProject list =
+    //     p2ps
+    //     // TODO before was no follow. now follow other projects too
+    //     // do not follow others lang project, is not supported by FCS anyway
+    //     // |> List.filter (fun p2p -> p2p.ProjectReferenceFullPath.ToLower().EndsWith(".fsproj"))
+    //     |> List.choose (fun p2p ->
+    //         let followP2pArgs =
+    //             p2p.TargetFramework
+    //             |> Option.map (fun tfm -> MSBuildKnownProperties.TargetFramework, tfm)
+    //             |> Option.toList
+    //         p2p.ProjectReferenceFullPath |> follow followP2pArgs )
+
+    let file =
+      match props |> Map.tryFind "MSBuildProjectFullPath" with
+        | Some t -> t
+        | None -> failwith "error, 'MSBuildProjectFullPath' property not found"
+
+    let projDir = Path.GetDirectoryName file
+
+    let tar =
+        match props |> Map.tryFind "TargetPath" with
+        | Some t -> t
+        | None -> failwith "error, 'TargetPath' property not found"
+
+    let rspNormalized =
+        //workaround, arguments in rsp can use relative paths
+        rsp |> List.map (FscArguments.useFullPaths projDir)
+
+    let sdkTypeData =
+      let extraInfo = getExtraInfo props
+      ProjectSdkType.DotnetSdk(extraInfo)
+
+    let isSourceFile : (string -> bool) =
+        if Path.GetExtension(file) = ".fsproj" then
+            FscArguments.isCompileFile
+        else
+            (fun n -> n.EndsWith ".cs")
+
+    let sourceFiles, otherOptions =
+        rspNormalized
+        |> List.partition isSourceFile
+
+    let compileItems =
+        sourceFiles
+        |> List.map (VisualTree.getCompileProjectItem projItems file)
+
+    let po =
+        {
+            ProjectId = Some file
+            ProjectFileName = file
+            TargetFramework =
+                match sdkTypeData with
+                | ProjectSdkType.DotnetSdk t ->
+                    t.TargetFramework
+                | ProjectSdkType.Verbose v ->
+                    v.TargetFrameworkVersion |> Dotnet.ProjInfo.NETFramework.netifyTargetFrameworkVersion
+            SourceFiles = sourceFiles
+            OtherOptions = otherOptions
+            ReferencedProjects = p2ps |> List.map (fun (y: Inspect.ResolvedP2PRefsInfo) -> { ProjectReference.ProjectFileName = y.ProjectReferenceFullPath; TargetFramework = (defaultArg y.TargetFramework "") })
+            LoadTime = DateTime.Now
+            Items = compileItems
+            ExtraProjectInfo =
+                {
+                    TargetPath = tar
+                    ExtraProjectInfoData.ProjectSdkType = sdkTypeData
+                    ExtraProjectInfoData.ProjectOutputType = FscArguments.outType rspNormalized
+                }
+        }
+
+    (tar, po)
+
+  let mapParseResults result =
+    match result with
+    | [getFscArgsResult; getP2PRefsResult; gpResult; gpItemResult] ->
+        match getFscArgsResult, getP2PRefsResult, gpResult, gpItemResult with
+        | MsbuildOk (Inspect.GetResult.FscArgs fa), MsbuildOk (Inspect.GetResult.ResolvedP2PRefs p2p), MsbuildOk (Inspect.GetResult.Properties p), MsbuildOk (Inspect.GetResult.Items pi) ->
+            Ok (fa, p2p, p |> Map.ofList, pi)
+        | r ->
+            Error (sprintf "error getting msbuild info: %A" r)
+    | r ->
+      Error (sprintf "error getting msbuild info: internal error, more info returned than expected %A" r)
+
+  let mapMSBuildResults (results, log) =
+    match results with
+    | MsbuildOk _ -> Ok ()
+    | MsbuildError r ->
+        match r with
+        | Dotnet.ProjInfo.Inspect.GetProjectInfoErrors.MSBuildSkippedTarget ->
+            Error "Unexpected MSBuild result, all targets skipped"
+        | Dotnet.ProjInfo.Inspect.GetProjectInfoErrors.UnexpectedMSBuildResult(r) ->
+            Error (sprintf "Unexpected MSBuild result %s" r)
+        | Dotnet.ProjInfo.Inspect.GetProjectInfoErrors.MSBuildFailed(exitCode, (workDir, exePath, args)) ->
+            let logMsg = [ yield "Log: "; yield! log ] |> String.concat (Environment.NewLine)
+            let msbuildErrorMsg =
+                [ sprintf "MSBuild failed with exitCode %i" exitCode
+                  sprintf "Working Directory: '%s'" workDir
+                  sprintf "Exe Path: '%s'" exePath
+                  sprintf "Args: '%s'" args ]
+                |> String.concat " "
+
+            Error (sprintf "%s%s%s" msbuildErrorMsg (Environment.NewLine) logMsg)
+    | _ ->
+        Error "error getting msbuild info: internal error"
+
+
+  let private execProjInfoFromMsbuild msbuildPath (notifyState: WorkspaceProjectState -> unit) (useBinaryLogger: bool) additionalMSBuildProps (solutionFile: string) =
+
+    let projDir = Path.GetDirectoryName solutionFile
+
+    let loggedMessages = ConcurrentQueue<string>()
+
+    let eventHandler = Event<string * list<Result<Inspect.GetResult,Inspect.GetProjectInfoErrors<_>>>> ()
+    let handel (name,  lst: list<Result<Inspect.GetResult,Inspect.GetProjectInfoErrors<_>>>) =
+        let res =
+          mapParseResults lst
+          |> Result.map (fun po -> mapProjResults name po)
+        match res with
+        | Ok (target, po) ->
+          WorkspaceProjectState.Loaded(po, Map.empty, false)
+          |> notifyState
+        | Error e ->
+          WorkspaceProjectState.Failed(name, GetProjectOptionsErrors.GenericError(name, e))
+          |> notifyState
+        ()
+
+    use handler = eventHandler.Publish.Subscribe (handel)
+
+    notifyState (WorkspaceProjectState.Loading (solutionFile, additionalMSBuildProps))
+
+    let getP2PRefs = Inspect.getResolvedP2PRefs
+    let additionalInfo = //needed for extra
+        [ "OutputType"
+          "IsTestProject"
+          "TargetPath"
+          "Configuration"
+          "IsPackable"
+          MSBuildKnownProperties.TargetFramework
+          "TargetFrameworkIdentifier"
+          "TargetFrameworkVersion"
+          "MSBuildAllProjects"
+          "ProjectAssetsFile"
+          "RestoreSuccess"
+          "Configurations"
+          "TargetFrameworks"
+          "RunArguments"
+          "RunCommand"
+          "IsPublishable"
+          "BaseIntermediateOutputPath"
+          "MSBuildProjectFullPath"
+        ]
+    let gp () = Inspect.getProperties (["TargetPath"; "IsCrossTargetingBuild"; "TargetFrameworks"] @ additionalInfo)
+
+    let getItems () = Inspect.getItems [("Compile", Inspect.GetItemsModifier.FullPath); ("Compile", Inspect.GetItemsModifier.Custom("Link"))] []
+
+    let additionalArgs = additionalMSBuildProps |> List.map (Inspect.MSBuild.MSbuildCli.Property)
+
+    let globalArgs =
+        if useBinaryLogger then
+            [ Inspect.MSBuild.MSbuildCli.Switch("bl") ]
+        else
+            match Environment.GetEnvironmentVariable("DOTNET_PROJ_INFO_MSBUILD_BL") with
+            | "1" -> [ Inspect.MSBuild.MSbuildCli.Switch("bl") ]
+            | _ -> []
+
+    let runCmd exePath args = Utils.runProcess loggedMessages.Enqueue projDir exePath (args |> String.concat " ")
+    let msbuildExec = Inspect.msbuild msbuildPath runCmd
+    let infoResult = Inspect.runMsBuild loggedMessages.Enqueue msbuildExec [Inspect.getFscArgs; getP2PRefs; gp; getItems] (additionalArgs @ globalArgs) eventHandler solutionFile
+
+
+
+    infoResult, (loggedMessages.ToArray() |> Array.toList)
+
+  /// Runs msbuild on given solution file. Returns `Ok ()` in case of succesful MsBuild run, or `Error string` if MsBuild call failed.
+  /// Result doesn't say anything about actuall project parsing, just if it was possible to run MsBuild.
+  /// All project parsing result will be published using `notifyState` callback.
+  let load msbuildPath (useBinaryLogger: bool) (notifyState: WorkspaceProjectState -> unit) (solutionFile: string) =
+    execProjInfoFromMsbuild msbuildPath notifyState useBinaryLogger [] solutionFile
+    |> mapMSBuildResults

--- a/src/Dotnet.ProjInfo/Inspect.fs
+++ b/src/Dotnet.ProjInfo/Inspect.fs
@@ -169,7 +169,7 @@ let getFscArgs () =
           Condition=" '$(IsCrossTargetingBuild)' != 'true' "
           DependsOnTargets="ResolveReferences;CoreCompile">
     <PropertyGroup>
-        <_Inspect_FscArgs_OutFile>$(_Inspect_FscArgs_OutDir)\\$(MSBuildProjectName).FscArgs.txt</_Inspect_FscArgs_OutFile>
+        <_Inspect_FscArgs_OutFile>$(_Inspect_FscArgs_OutDir)\\$(MSBuildProjectFile)_FscArgs.txt</_Inspect_FscArgs_OutFile>
     </PropertyGroup>
     <Message Text="%(FscCommandLineArgs.Identity)" Importance="High" />
     <WriteLinesToFile
@@ -186,8 +186,8 @@ let getFscArgs () =
   </Target>
         """.Trim()
     let outFile projectPath =
-        let pp = Path.GetFileNameWithoutExtension projectPath
-        sprintf "%s\\%s.FscArgs.txt" outDir pp
+        let pp = Path.GetFileName projectPath
+        sprintf "%s\\%s_FscArgs.txt" outDir pp
     let args =
         [ Property ("SkipCompilerExecution", "true")
           Property ("ProvideCommandLineArgs" , "true")
@@ -211,7 +211,7 @@ let getCscArgs () =
           DependsOnTargets="ResolveReferences;CoreCompile">
     <Message Text="%(CscCommandLineArgs.Identity)" Importance="High" />
     <PropertyGroup>
-        <_Inspect_CscArgs_OutFile>$(_Inspect_CscArgs_OutDir)\\$(MSBuildProjectName).CscArgs.txt</_Inspect_CscArgs_OutFile>
+        <_Inspect_CscArgs_OutFile>$(_Inspect_CscArgs_OutDir)\\$(MSBuildProjectFile)_CscArgs.txt</_Inspect_CscArgs_OutFile>
     </PropertyGroup>
     <WriteLinesToFile
             Condition=" '$(_Inspect_CscArgs_OutFile)' != '' "
@@ -227,8 +227,8 @@ let getCscArgs () =
   </Target>
         """.Trim()
     let outFile projectPath =
-        let pp = Path.GetFileNameWithoutExtension projectPath
-        sprintf "%s\\%s.CscArgs.txt" outDir pp
+        let pp = Path.GetFileName projectPath
+        sprintf "%s\\%s_CscArgs.txt" outDir pp
     let args =
         [ Property ("SkipCompilerExecution", "true")
           Property ("ProvideCommandLineArgs" , "true")
@@ -250,7 +250,7 @@ let getP2PRefs () =
   <Target Name="_Inspect_GetProjectReferences">
     <Message Text="%(ProjectReference.FullPath)" Importance="High" />
     <PropertyGroup>
-        <_Inspect_GetProjectReferences_OutFile>$(_Inspect_GetProjectReferences_OutDir)\\$(MSBuildProjectName).GetProjectReferences.txt</_Inspect_GetProjectReferences_OutFile>
+        <_Inspect_GetProjectReferences_OutFile>$(_Inspect_GetProjectReferences_OutDir)\\$(MSBuildProjectFile)_GetProjectReferences.txt</_Inspect_GetProjectReferences_OutFile>
     </PropertyGroup>
     <WriteLinesToFile
             Condition=" '$(_Inspect_GetProjectReferences_OutFile)' != '' "
@@ -265,10 +265,9 @@ let getP2PRefs () =
         AlwaysCreate="True" />
   </Target>
         """.Trim()
-    let outFile = getNewTempFilePath "GetProjectReferences.txt"
     let outFile projectPath =
-        let pp = Path.GetFileNameWithoutExtension projectPath
-        sprintf "%s\\%s.GetProjectReferences.txt" outDir pp
+        let pp = Path.GetFileName projectPath
+        sprintf "%s\\%s_GetProjectReferences.txt" outDir pp
     let args =
         [ Target "_Inspect_GetProjectReferences"
           Property ("_Inspect_GetProjectReferences_OutDir", outDir) ]
@@ -304,7 +303,7 @@ let getProperties props =
           Condition=" '$(IsCrossTargetingBuild)' """ + (if isCrossgen then "==" else "!=") + """ 'true' "
           """ + (if isCrossgen then "" else "DependsOnTargets=\"ResolveReferences\"" ) + """ >
     <PropertyGroup>
-        <_Inspect_GetProperties_OutFile>$(_Inspect_GetProperties_OutDir)\\$(MSBuildProjectName).GetProperties.txt</_Inspect_GetProperties_OutFile>
+        <_Inspect_GetProperties_OutFile>$(_Inspect_GetProperties_OutDir)\\$(MSBuildProjectFile)_GetProperties.txt</_Inspect_GetProperties_OutFile>
     </PropertyGroup>
     <ItemGroup>
         """
@@ -347,8 +346,8 @@ let getProperties props =
         |> String.concat (System.Environment.NewLine)
 
     let outFile projectPath =
-        let pp = Path.GetFileNameWithoutExtension projectPath
-        sprintf "%s\\%s.GetProperties.txt" outDir pp
+        let pp = Path.GetFileName projectPath
+        sprintf "%s\\%s_GetProperties.txt" outDir pp
     let args =
         [ Target "_Inspect_GetProperties"
           Property ("_Inspect_GetProperties_OutDir", outDir) ]
@@ -434,7 +433,7 @@ let getItems items dependsOnTargets =
           Condition=" '$(IsCrossTargetingBuild)' != 'true' "
           DependsOnTargets="{0}">
           <PropertyGroup>
-            <_Inspect_Items_OutFile>$(_Inspect_Items_OutDir)\\$(MSBuildProjectName).Items.txt</_Inspect_Items_OutFile>
+            <_Inspect_Items_OutFile>$(_Inspect_Items_OutDir)\\$(MSBuildProjectFile)_Items.txt</_Inspect_Items_OutFile>
           </PropertyGroup>
                               """, dependsOnTargetsProperty)
 
@@ -466,8 +465,8 @@ let getItems items dependsOnTargets =
         |> String.concat (Environment.NewLine)
 
     let outFile projectPath =
-        let pp = Path.GetFileNameWithoutExtension projectPath
-        sprintf "%s\\%s.Items.txt" outDir pp
+        let pp = Path.GetFileName projectPath
+        sprintf "%s\\%s_Items.txt" outDir pp
     let args =
         [ Target "_Inspect_Items"
           Property ("_Inspect_Items_OutDir", outDir) ]
@@ -526,7 +525,7 @@ let getResolvedP2PRefs () =
           Condition=" '$(IsCrossTargetingBuild)' != 'true' "
           DependsOnTargets="ResolveProjectReferencesDesignTime">
     <PropertyGroup>
-        <_Inspect_GetResolvedProjectReferences_OutFile>$(_Inspect_GetResolvedProjectReferences_OutDir)\\$(MSBuildProjectName).GetResolvedProjectReferences.txt</_Inspect_GetResolvedProjectReferences_OutFile>
+        <_Inspect_GetResolvedProjectReferences_OutFile>$(_Inspect_GetResolvedProjectReferences_OutDir)\\$(MSBuildProjectFile)_GetResolvedProjectReferences.txt</_Inspect_GetResolvedProjectReferences_OutFile>
     </PropertyGroup>
     <Message Text="%(_MSBuildProjectReferenceExistent.FullPath)" Importance="High" />
     <Message Text="%(_MSBuildProjectReferenceExistent.SetTargetFramework)" Importance="High" />
@@ -544,8 +543,8 @@ let getResolvedP2PRefs () =
   </Target>
         """.Trim()
     let outFile projectPath =
-        let pp = Path.GetFileNameWithoutExtension projectPath
-        sprintf "%s\\%s.GetResolvedProjectReferences.txt" outDir pp
+        let pp = Path.GetFileName projectPath
+        sprintf "%s\\%s_GetResolvedProjectReferences.txt" outDir pp
     let args =
         [ Property ("DesignTimeBuild", "true")
           Target "_Inspect_GetResolvedProjectReferences"
@@ -593,6 +592,43 @@ let getProjectInfo log msbuildExec getArgs (projPath: string) =
     |> Result.bind (fun targetPath -> msbuildExec projPath (args @ [ Property("CustomAfterMicrosoftCommonTargets", targetPath) ]))
     |> Result.bind (fun _ -> parse projPath)
 
+/// Runs MsBuild on given project or solution. Blocking call. Result shows if the msbuild managed to run, not an actuall content of the project files.
+///
+let runMsBuild log msbuildExec getters additionalArgs (notify: Event<_>) (path: string) =
+
+    let templates, argsList, parsers =
+        getters
+        |> List.map (fun getArgs -> getArgs ())
+        |> List.unzip3
+
+    let args = argsList |> List.concat
+
+    // remove deprecated target file, if exists
+    path
+    |> uninstall_old_target_file log
+
+    use watcher = new FileSystemWatcher(outDir, "*_Items.txt")
+    watcher.Created.Add (fun t ->
+        let projName = t.Name.Split('_').[0]
+        let res =
+            parsers
+            |> List.map (fun parse ->
+                try
+                    parse projName
+                with
+                | :? System.IO.IOException ->
+                    Threading.Thread.Sleep 50
+                    parse projName)
+        notify.Trigger (projName, res)
+
+        ())
+
+    watcher.EnableRaisingEvents <- true
+
+    getNewTempFilePath "proj-info.hook.targets"
+    |> writeTargetFile log templates
+    |> Result.bind (fun targetPath -> msbuildExec path (args @ additionalArgs @ [ Property("CustomAfterMicrosoftCommonTargets", targetPath); Property("CustomAfterMicrosoftCommonCrossTargetingTargets", targetPath) ]))
+
 let getFscArgsOldSdk propsToFscArgs () =
 
     let props = FakeMsbuildTasks.getFscTaskProperties ()
@@ -602,7 +638,7 @@ let getFscArgsOldSdk propsToFscArgs () =
   <!-- Override CoreCompile target -->
   <Target Name="CoreCompile" DependsOnTargets="$(CoreCompileDependsOn)">
     <PropertyGroup>
-        <_Inspect_CoreCompilePropsOldSdk_OutFile>$(_Inspect_CoreCompilePropsOldSdk_OutDir)\\$(MSBuildProjectName).CoreCompilePropsOldSdk.txt</_Inspect_CoreCompilePropsOldSdk_OutFile>
+        <_Inspect_CoreCompilePropsOldSdk_OutFile>$(_Inspect_CoreCompilePropsOldSdk_OutDir)\\$(MSBuildProjectFile)_CoreCompilePropsOldSdk.txt</_Inspect_CoreCompilePropsOldSdk_OutFile>
     </PropertyGroup>
     <ItemGroup>
         """
@@ -629,8 +665,8 @@ let getFscArgsOldSdk propsToFscArgs () =
   </Target>
         """.Trim()
     let outFile projectPath =
-        let pp = Path.GetFileNameWithoutExtension projectPath
-        sprintf "%s\\%s.CoreCompilePropsOldSdk.txt" outDir pp
+        let pp = Path.GetFileName projectPath
+        sprintf "%s\\%s_CoreCompilePropsOldSdk.txt" outDir pp
     let args =
         [ Property ("CopyBuildOutputToOutputDirectory", "false")
           Property ("UseCommonOutputDirectory", "true")

--- a/src/Dotnet.ProjInfo/NETFrameworkInfoFromMSBuild.fs
+++ b/src/Dotnet.ProjInfo/NETFrameworkInfoFromMSBuild.fs
@@ -39,7 +39,7 @@ let getReferencePaths props =
             Lines="@(ReferencePath -> 'ReferencePath=%(Identity)')"
             Overwrite="true"
             Encoding="UTF-8"/>
-            
+
     <!-- WriteLinesToFile doesnt create the file if @(ReferencePath) is empty -->
     <Touch
         Condition=" '$(_GetFsxScriptReferences_OutFile)' != '' "
@@ -56,9 +56,10 @@ let getReferencePaths props =
     //   FrameworkPathOverride = lines |> List.tryPick (chooseByPrefix "FrameworkPathOverride=")
     //   ReferencePath = lines |> List.choose (chooseByPrefix "ReferencePath=") }
 
-    template, args, (fun () -> outFile
-                               |> Inspect.bindSkipped Inspect.parsePropertiesOut
-                               |> Result.map (List.map snd >> Inspect.GetResult.ResolvedNETRefs))
+    template, args, (fun projectPath ->
+                          outFile
+                          |> Inspect.bindSkipped Inspect.parsePropertiesOut
+                          |> Result.map (List.map snd >> Inspect.GetResult.ResolvedNETRefs))
 
 
 let [<Literal>] private FrameworkPathOverride = "FrameworkPathOverride"
@@ -87,8 +88,8 @@ let installedNETFrameworks () =
       |> List.distinct
       |> Inspect.GetResult.InstalledNETFw
 
-    let findInstalledNETFw () =
-        parser ()
+    let findInstalledNETFw (projectPath: string) =
+        parser projectPath
         |> Result.bind (fun p ->
             match p with
             | Inspect.GetResult.Properties props ->


### PR DESCRIPTION
This is mostly investigating if it would be possible to run Design Time Build directly on `.sln` file, rather than on the list of projects. Potentially it should lead to better performance but requires sizeable changes in the codebase - it will require some event-driven approach to the thing, rather than calling MSBuild synchronously. 