### PR TITLE
Provide solution project file order API

### DIFF
--- a/src/Dotnet.ProjInfo.Workspace/InspectSln.fs
+++ b/src/Dotnet.ProjInfo.Workspace/InspectSln.fs
@@ -1,6 +1,6 @@
 namespace Dotnet.ProjInfo.Workspace
 
-module internal InspectSln =
+module InspectSln =
 
   open System
   open System.IO
@@ -91,9 +91,9 @@ module internal InspectSln =
         slnFilePath
         |> Microsoft.Build.Construction.SolutionFile.Parse
         |> parseSln
-        |> Choice1Of2
+        |> Ok
     with ex ->
-        Choice2Of2 ex
+        Error ex
 
   let loadingBuildOrder (data: SolutionData) =
 

--- a/src/Dotnet.ProjInfo.Workspace/Library.fs
+++ b/src/Dotnet.ProjInfo.Workspace/Library.fs
@@ -147,11 +147,11 @@ type Loader private (msbuildHostDotNetSdk, msbuildHostVerboseSdk) =
         let numberOfThreads = defaultArg numberOfThreads 1
 
         match InspectSln.tryParseSln slnPath with
-        | Choice1Of2 (_, slnData) ->
+        | Ok (_, slnData) ->
             let projs = InspectSln.loadingBuildOrder slnData
 
             this.LoadProjects(projs, crosstargetingStrategy, useBinaryLogger, numberOfThreads)
-        | Choice2Of2 d ->
+        | Error d ->
             failwithf "cannot load the sln: %A" d
 
     static member Create(config: LoaderConfig) =

--- a/src/Dotnet.ProjInfo/Inspect.fs
+++ b/src/Dotnet.ProjInfo/Inspect.fs
@@ -136,10 +136,9 @@ type GetResult =
      | InstalledNETFw of string list
 and ResolvedP2PRefsInfo = { ProjectReferenceFullPath: string; TargetFramework: string option; Others: (string * string) list }
 
+// See https://stackoverflow.com/questions/581570/how-can-i-create-a-temp-file-with-a-specific-extension-with-net
 let getNewTempFilePath suffix =
-    let outFile = System.IO.Path.GetTempFileName()
-    if File.Exists outFile then File.Delete outFile
-    sprintf "%s.%s" outFile suffix
+    Path.GetTempPath() + Guid.NewGuid().ToString() + suffix 
 
 let bindSkipped f outFile =
     if not(File.Exists outFile) then


### PR DESCRIPTION
Two things

1. Expose the solution file cracking API and project file load order (without a full call to LoadSln)

2. Fix the acquisition of a temp file with a suffix, per https://stackoverflow.com/questions/581570/how-can-i-create-a-temp-file-with-a-specific-extension-with-net.  The current approach wasn't always working in multi-threaded execution, with different paths returning the same temp file name

